### PR TITLE
feat: add greasemonkey scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pipx install git+https://github.com/thatlittleboy/lgtm-db
 ```
 
 ## 🚀 Usage
+### CLI
 This project exposes a simple CLI API that prints out the HTML img tag of a randomly selected gif/image in the db.
 
 ```shell
@@ -34,13 +35,17 @@ You can then pipe the result into `pbcopy` etc. to copy the result into your cli
 
 **NOTE**: API is very much subject to change.
 
+### Browser user script
+Integration with the browser is experimental.
+You need to install Greasemonkey / Tampermonkey, and invoke a user script to insert a random gif into the message box (upon PR approval, or any other event you would like).
+
+Sample user scripts for Gitlab and Github are found in [scripts/greasemonkey].
+
 ## 📝 Todo
 Things that I may or may not get around to doing...
 * write a local pre-commit hook in this repo to test:
   * if there are duplicated names (id's should be unique)
   * if there are duplicated urls
-* write a sample greasemonkey script to automatically add the img tag of a random on work gitlab (cf. https://github.com/chriskuehl/shipit/blob/master/shipit.user.js)
-  * for gitlab, there's no approve button; my idea is to look out for `/lgtm` quick action and replace the whole message body with a random lgtm-db asset
 * supporting cli args
   * default with no args should print help message
   * selecting random static imgs or gifs: `lgtm-db random`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can then pipe the result into `pbcopy` etc. to copy the result into your cli
 Integration with the browser is experimental.
 You need to install Greasemonkey / Tampermonkey, and invoke a user script to insert a random gif into the message box (upon PR approval, or any other event you would like).
 
-Sample user scripts for Gitlab and Github are found in [scripts/greasemonkey].
+Sample user scripts for Gitlab and Github are found in the [scripts folder](scripts/greasemonkey).
 
 ## 📝 Todo
 Things that I may or may not get around to doing...

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ You can then pipe the result into `pbcopy` etc. to copy the result into your cli
 
 ### Browser user script
 Integration with the browser is experimental.
-You need to install Greasemonkey / Tampermonkey, and invoke a user script to insert a random gif into the message box (upon PR approval, or any other event you would like).
+You need to install Greasemonkey / Tampermonkey, and invoke a user script to insert a random gif into the message box (upon PR approval, or any other Javascript event you like).
 
 Sample user scripts for Gitlab and Github are found in the [scripts folder](scripts/greasemonkey).
+
+(Gifs demonstrating this to be done?)
 
 ## 📝 Todo
 Things that I may or may not get around to doing...

--- a/scripts/greasemonkey/lgtm-gifs-github.user.js
+++ b/scripts/greasemonkey/lgtm-gifs-github.user.js
@@ -1,0 +1,55 @@
+// ==UserScript==
+// @name         lgtm-gifs-github
+// @namespace    https://www.github.com/thatlittleboy
+// @version      1.0
+// @author       thatlittleboy
+// @include      https://github.com/*/*/pull/*
+// @require      https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js
+// @grant        GM.xmlHttpRequest
+// ==/UserScript==
+
+(function () {
+    console.log("Greasemonkey lgtm-gifs-github running...");
+    let all_lgtm;
+
+    GM.xmlHttpRequest({
+        method: "GET",
+        url: "https://raw.githubusercontent.com/thatlittleboy/lgtm-db/main/lgtm_db/data/db.yaml",
+        onload: function (resp) {
+            if (resp.status === 200) {
+                try {
+                    const ymldoc = jsyaml.load(resp.response);
+                    all_lgtm = ymldoc["gifs"].concat(ymldoc["images"]);
+                } catch (e) {
+                    console.log("error", e);
+                    all_lgtm = [];
+                }
+                // console.log(all_lgtm);
+            }
+        },
+    });
+
+    document.body.addEventListener("click", function (e) {
+        let msg;
+        console.log(
+            "click event registered. name:",
+            e.target.name,
+            ", value:",
+            e.target.value
+        );
+
+        if (all_lgtm.length && e.target.name === "pull_request_review[event]" && e.target.value === "approve") {
+            console.log("inside approved if-block");
+
+            // user just clicked on the "Approve" button
+            // find the comment box by id
+            msg = document.querySelector("#pull_request_review_body");
+
+            // select a random gif
+            const selected = all_lgtm[Math.floor(Math.random() * all_lgtm.length)];
+
+            // replace the msg value
+            msg.value = `${msg.value}\n\n![${selected.name}](${selected.url})`;
+        }
+    });
+})();

--- a/scripts/greasemonkey/lgtm-gifs-gitlab.user.js
+++ b/scripts/greasemonkey/lgtm-gifs-gitlab.user.js
@@ -1,0 +1,56 @@
+// ==UserScript==
+// @name         lgtm-gifs-gitlab
+// @namespace    https://www.github.com/thatlittleboy
+// @version      1.0
+// @author       thatlittleboy
+// @include      https://gitlab.com/*/*/-/merge_requests/*
+// @require      https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js
+// @grant        GM.xmlHttpRequest
+// ==/UserScript==
+
+(function () {
+    console.log("Greasemonkey lgtm-gifs-gitlab running...");
+    let all_lgtm;
+
+    GM.xmlHttpRequest({
+        method: "GET",
+        url: "https://raw.githubusercontent.com/thatlittleboy/lgtm-db/main/lgtm_db/data/db.yaml",
+        onload: function (resp) {
+            if (resp.status === 200) {
+                try {
+                    const ymldoc = jsyaml.load(resp.response);
+                    all_lgtm = ymldoc["gifs"].concat(ymldoc["images"]);
+                } catch (e) {
+                    console.log("error", e);
+                    all_lgtm = [];
+                }
+                // console.log(all_lgtm);
+            }
+        },
+    });
+
+    document.body.addEventListener("click", function (e) {
+        let msg;
+        console.log(
+            "click event registered. className:",
+            e.target.className,
+            ", innerText:",
+            e.target.innerText
+        );
+
+        if (all_lgtm.length && e.target.className === "gl-button-text" && e.target.innerText === "Approve") {
+            console.log("inside approved if-block");
+
+            // user just clicked on the "Approve" button
+            // find the comment box by id
+            msg = document.querySelector("#note-body");
+
+            // select a random gif
+            const selected = all_lgtm[Math.floor(Math.random() * all_lgtm.length)];
+
+            // replace the msg value
+            msg.value = `${msg.value}\n\n![${selected.name}](${selected.url})`;
+            msg.dispatchEvent(new Event("change"));
+        }
+    });
+})();


### PR DESCRIPTION
Added 2 greasemonkey scripts for injecting lgtm gifs into the message box of Github and Gitlab upon PR approval.

--- 

Huge inspiration from [here](https://github.com/chriskuehl/shipit/blob/master/shipit.user.js);  
Modified this script slightly to fit into gitlab's architecture.

The final `dispatchEvent` is extremely important in Gitlab's case, otherwise the actual message value change is not propagated. See https://stackoverflow.com/a/39244729.