### PR TITLE
feat: add width-height

### DIFF
--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -1,71 +1,71 @@
 ## Images
 
-**Name**: git-push-and-go-home<br><img alt="git-push-and-go-home" src="https://i.imgur.com/PKiCvz2.png" width="420">
+**Name**: git-push-and-go-home<br><img alt="git-push-and-go-home" src="https://i.imgur.com/PKiCvz2.png" width="420" height="420">
 
-**Name**: doge-much-code-very-lgtm<br><img alt="doge-much-code-very-lgtm" src="https://memegenerator.net/img/instances/64675441.jpg" width="420">
+**Name**: doge-much-code-very-lgtm<br><img alt="doge-much-code-very-lgtm" src="https://memegenerator.net/img/instances/64675441.jpg" width="420" height="315">
 
-**Name**: success-kid-shipit<br><img alt="success-kid-shipit" src="https://memegenerator.net/img/instances/68718219.jpg" width="420">
+**Name**: success-kid-shipit<br><img alt="success-kid-shipit" src="https://memegenerator.net/img/instances/68718219.jpg" width="420" height="420">
 
 ## Gifs
 
-**Name**: seal-of-approval-seal<br><img alt="seal-of-approval-seal" src="https://media.giphy.com/media/13zeE9qQNC5IKk/giphy.gif" width="420">
+**Name**: seal-of-approval-seal<br><img alt="seal-of-approval-seal" src="https://media.giphy.com/media/13zeE9qQNC5IKk/giphy.gif" width="420" height="283">
 
-**Name**: spongebob-many-thumbs-up<br><img alt="spongebob-many-thumbs-up" src="https://media.giphy.com/media/3o7abGQa0aRJUurpII/giphy.gif" width="420">
+**Name**: spongebob-many-thumbs-up<br><img alt="spongebob-many-thumbs-up" src="https://media.giphy.com/media/3o7abGQa0aRJUurpII/giphy.gif" width="420" height="236">
 
-**Name**: squidward-lacklustre-hooray<br><img alt="squidward-lacklustre-hooray" src="https://media.giphy.com/media/l0HlTUsy3ZOuDSQtG/giphy.gif" width="420">
+**Name**: squidward-lacklustre-hooray<br><img alt="squidward-lacklustre-hooray" src="https://media.giphy.com/media/l0HlTUsy3ZOuDSQtG/giphy.gif" width="420" height="236">
 
-**Name**: spongebob-patrick-hooray<br><img alt="spongebob-patrick-hooray" src="https://media.giphy.com/media/3ohzAu2U1tOafteBa0/giphy.gif" width="420">
+**Name**: spongebob-patrick-hooray<br><img alt="spongebob-patrick-hooray" src="https://media.giphy.com/media/3ohzAu2U1tOafteBa0/giphy.gif" width="420" height="315">
 
-**Name**: simon-cowell-agt-thumbsup<br><img alt="simon-cowell-agt-thumbsup" src="https://media.giphy.com/media/gqao9nM8RcSnYMgHnp/giphy.gif" width="420">
+**Name**: simon-cowell-agt-thumbsup<br><img alt="simon-cowell-agt-thumbsup" src="https://media.giphy.com/media/gqao9nM8RcSnYMgHnp/giphy.gif" width="420" height="420">
 
-**Name**: terminator2-thumbsup<br><img alt="terminator2-thumbsup" src="https://media.giphy.com/media/gFwZfXIqD0eNW/giphy.gif" width="420">
+**Name**: terminator2-thumbsup<br><img alt="terminator2-thumbsup" src="https://media.giphy.com/media/gFwZfXIqD0eNW/giphy.gif" width="420" height="177">
 
-**Name**: baby-girl-thumbsup-thankyou<br><img alt="baby-girl-thumbsup-thankyou" src="https://media.giphy.com/media/BYoRqTmcgzHcL9TCy1/giphy.gif" width="420">
+**Name**: baby-girl-thumbsup-thankyou<br><img alt="baby-girl-thumbsup-thankyou" src="https://media.giphy.com/media/BYoRqTmcgzHcL9TCy1/giphy.gif" width="420" height="422">
 
-**Name**: sand-dune-shipit<br><img alt="sand-dune-shipit" src="https://media.giphy.com/media/xjZtu4qi1biIo/giphy.gif" width="420">
+**Name**: sand-dune-shipit<br><img alt="sand-dune-shipit" src="https://media.giphy.com/media/xjZtu4qi1biIo/giphy.gif" width="420" height="315">
 
-**Name**: asian-man-cubicle-thumbsup<br><img alt="asian-man-cubicle-thumbsup" src="https://media.giphy.com/media/GCvktC0KFy9l6/giphy.gif" width="420">
+**Name**: asian-man-cubicle-thumbsup<br><img alt="asian-man-cubicle-thumbsup" src="https://media.giphy.com/media/GCvktC0KFy9l6/giphy.gif" width="420" height="448">
 
-**Name**: cat-wearing-shades-letsgo<br><img alt="cat-wearing-shades-letsgo" src="https://media.giphy.com/media/CjmvTCZf2U3p09Cn0h/giphy.gif" width="420">
+**Name**: cat-wearing-shades-letsgo<br><img alt="cat-wearing-shades-letsgo" src="https://media.giphy.com/media/CjmvTCZf2U3p09Cn0h/giphy.gif" width="420" height="395">
 
-**Name**: nicholas-cage-letsgo<br><img alt="nicholas-cage-letsgo" src="https://media.giphy.com/media/RrVzUOXldFe8M/giphy.gif" width="420">
+**Name**: nicholas-cage-letsgo<br><img alt="nicholas-cage-letsgo" src="https://media.giphy.com/media/RrVzUOXldFe8M/giphy.gif" width="420" height="315">
 
-**Name**: wwe-referee-thumbsup<br><img alt="wwe-referee-thumbsup" src="https://c.tenor.com/JS6Vtap-SYEAAAAC/wwe-wrestling.gif" width="420">
+**Name**: wwe-referee-thumbsup<br><img alt="wwe-referee-thumbsup" src="https://c.tenor.com/JS6Vtap-SYEAAAAC/wwe-wrestling.gif" width="420" height="328">
 
-**Name**: domino-effect-self-high-five<br><img alt="domino-effect-self-high-five" src="https://c.tenor.com/WBSIMZ5mHYAAAAAd/domino-effect-high-five.gif" width="420">
+**Name**: domino-effect-self-high-five<br><img alt="domino-effect-self-high-five" src="https://c.tenor.com/WBSIMZ5mHYAAAAAd/domino-effect-high-five.gif" width="420" height="410">
 
-**Name**: trump-showing-lgtm<br><img alt="trump-showing-lgtm" src="http://i.imgur.com/JebWqWC.gif" width="420">
+**Name**: trump-showing-lgtm<br><img alt="trump-showing-lgtm" src="http://i.imgur.com/JebWqWC.gif" width="420" height="366">
 
-**Name**: borat-great-success<br><img alt="borat-great-success" src="https://media.giphy.com/media/a0h7sAqON67nO/giphy.gif" width="420">
+**Name**: borat-great-success<br><img alt="borat-great-success" src="https://media.giphy.com/media/a0h7sAqON67nO/giphy.gif" width="420" height="236">
 
-**Name**: walkby-cat-high-five-shipit<br><img alt="walkby-cat-high-five-shipit" src="https://i.fluffy.cc/MKjDMmwXxZlqRTwnn070gVqZ8Rwh6d3p.gif" width="420">
+**Name**: walkby-cat-high-five-shipit<br><img alt="walkby-cat-high-five-shipit" src="https://i.fluffy.cc/MKjDMmwXxZlqRTwnn070gVqZ8Rwh6d3p.gif" width="420" height="235">
 
-**Name**: dog-in-front-of-laptop-lgtm<br><img alt="dog-in-front-of-laptop-lgtm" src="https://media.giphy.com/media/eM0U5NQtVHu30VM5sS/giphy.gif" width="420">
+**Name**: dog-in-front-of-laptop-lgtm<br><img alt="dog-in-front-of-laptop-lgtm" src="https://media.giphy.com/media/eM0U5NQtVHu30VM5sS/giphy.gif" width="420" height="425">
 
-**Name**: joey-friends-nice<br><img alt="joey-friends-nice" src="https://media.giphy.com/media/ftYpwfV6ZcerEa8poV/giphy.gif" width="420">
+**Name**: joey-friends-nice<br><img alt="joey-friends-nice" src="https://media.giphy.com/media/ftYpwfV6ZcerEa8poV/giphy.gif" width="420" height="343">
 
-**Name**: dog-dressed-as-human-lgtm<br><img alt="dog-dressed-as-human-lgtm" src="https://media.giphy.com/media/gLuP6eGC3yamBoGMJT/giphy.gif" width="420">
+**Name**: dog-dressed-as-human-lgtm<br><img alt="dog-dressed-as-human-lgtm" src="https://media.giphy.com/media/gLuP6eGC3yamBoGMJT/giphy.gif" width="420" height="236">
 
-**Name**: gordon-ramsey-brilliant<br><img alt="gordon-ramsey-brilliant" src="https://media.giphy.com/media/3oFzlX9khlRIev1E2Y/giphy.gif" width="420">
+**Name**: gordon-ramsey-brilliant<br><img alt="gordon-ramsey-brilliant" src="https://media.giphy.com/media/3oFzlX9khlRIev1E2Y/giphy.gif" width="420" height="236">
 
-**Name**: pedro-pascal-fist-salute<br><img alt="pedro-pascal-fist-salute" src="https://media.giphy.com/media/n58MqIchLqAalRQAQB/giphy.gif" width="420">
+**Name**: pedro-pascal-fist-salute<br><img alt="pedro-pascal-fist-salute" src="https://media.giphy.com/media/n58MqIchLqAalRQAQB/giphy.gif" width="420" height="236">
 
-**Name**: choi-aera-fightformyway-thumbsup<br><img alt="choi-aera-fightformyway-thumbsup" src="https://media.giphy.com/media/PL6d4VCbp1hhkF2wO9/giphy.gif" width="420">
+**Name**: choi-aera-fightformyway-thumbsup<br><img alt="choi-aera-fightformyway-thumbsup" src="https://media.giphy.com/media/PL6d4VCbp1hhkF2wO9/giphy.gif" width="420" height="272">
 
-**Name**: this-is-a-high-five-moment<br><img alt="this-is-a-high-five-moment" src="https://media.giphy.com/media/w5S93jM3bA3rbPTOpO/giphy.gif" width="420">
+**Name**: this-is-a-high-five-moment<br><img alt="this-is-a-high-five-moment" src="https://media.giphy.com/media/w5S93jM3bA3rbPTOpO/giphy.gif" width="420" height="236">
 
-**Name**: unwilling-cat-low-five-shipit<br><img alt="unwilling-cat-low-five-shipit" src="https://media.giphy.com/media/TLKp7l4rdWFMVfN5hP/giphy.gif" width="420">
+**Name**: unwilling-cat-low-five-shipit<br><img alt="unwilling-cat-low-five-shipit" src="https://media.giphy.com/media/TLKp7l4rdWFMVfN5hP/giphy.gif" width="420" height="253">
 
-**Name**: cat-standing-thankyou<br><img alt="cat-standing-thankyou" src="https://media.giphy.com/media/ucI5kRLqH0WXu/giphy.gif" width="420">
+**Name**: cat-standing-thankyou<br><img alt="cat-standing-thankyou" src="https://media.giphy.com/media/ucI5kRLqH0WXu/giphy.gif" width="420" height="746">
 
-**Name**: multiple-pikachu-shipit<br><img alt="multiple-pikachu-shipit" src="https://i.fluffy.cc/BPgxZkmsrgmfcDFDCNWC3m4CW0gCJF7w.gif" width="420">
+**Name**: multiple-pikachu-shipit<br><img alt="multiple-pikachu-shipit" src="https://i.fluffy.cc/BPgxZkmsrgmfcDFDCNWC3m4CW0gCJF7w.gif" width="420" height="236">
 
-**Name**: sitting-cat-high-five<br><img alt="sitting-cat-high-five" src="https://i.fluffy.cc/TNRR0PklwSCMZlZHQkvpQPNl8h50SpgP.gif" width="420">
+**Name**: sitting-cat-high-five<br><img alt="sitting-cat-high-five" src="https://i.fluffy.cc/TNRR0PklwSCMZlZHQkvpQPNl8h50SpgP.gif" width="420" height="236">
 
-**Name**: husky-jumping-shipit<br><img alt="husky-jumping-shipit" src="https://i.fluffy.cc/b6wlBbdVkX83CHpLWxHZw74WJxHVQc9S.gif" width="420">
+**Name**: husky-jumping-shipit<br><img alt="husky-jumping-shipit" src="https://i.fluffy.cc/b6wlBbdVkX83CHpLWxHZw74WJxHVQc9S.gif" width="420" height="445">
 
-**Name**: carrying-dog-shipit-plz<br><img alt="carrying-dog-shipit-plz" src="https://i.fluffy.cc/7WXqprWzDtCpbfprBZG1Hngnp7H7pfQm.gif" width="420">
+**Name**: carrying-dog-shipit-plz<br><img alt="carrying-dog-shipit-plz" src="https://i.fluffy.cc/7WXqprWzDtCpbfprBZG1Hngnp7H7pfQm.gif" width="420" height="232">
 
-**Name**: kitten-low-five-shipit<br><img alt="kitten-low-five-shipit" src="https://i.fluffy.cc/3X84Bq2RR182XcPr0NTKKCp7wvNT8MhD.gif" width="420">
+**Name**: kitten-low-five-shipit<br><img alt="kitten-low-five-shipit" src="https://i.fluffy.cc/3X84Bq2RR182XcPr0NTKKCp7wvNT8MhD.gif" width="420" height="226">
 
-**Name**: believe-flying-puppy-shipit<br><img alt="believe-flying-puppy-shipit" src="https://media.giphy.com/media/37YkA62o0EacPqD0xm/giphy.gif" width="420">
+**Name**: believe-flying-puppy-shipit<br><img alt="believe-flying-puppy-shipit" src="https://media.giphy.com/media/37YkA62o0EacPqD0xm/giphy.gif" width="420" height="396">

--- a/lgtm_db/__init__.py
+++ b/lgtm_db/__init__.py
@@ -18,17 +18,21 @@ class StringOutputFormat(str, enum.Enum):
 
 
 def gif_to_string_output(
-    name: str,
-    url: str,
+    gif: dict,
     output_format: StringOutputFormat,
-    width: Optional[int] = None,
+    desired_width: Optional[int] = None,
 ) -> str:
+    name = gif["name"]
+    url = gif["url"]
+    aspect_ratio = gif["width"] / gif["height"]
+
     if output_format == StringOutputFormat.HTML:
-        width = width or 500
-        return f'<img alt="{name}" src="{url}" width="{width}">'
+        width = desired_width or 500  # TODO: add logic for gif["width"]
+        height = width / aspect_ratio
+        return f'<img alt="{name}" src="{url}" width="{width}" height="{height}">'
     if output_format == StringOutputFormat.MARKDOWN:
-        if width is not None:
-            raise ValueError("width is not supported when output_format is Markdown")
+        if desired_width is not None:
+            raise ValueError("desired_width is not supported when output_format is Markdown")
         return f"![{name}]({url})"
     raise ValueError(f"output_format: {output_format!r} not supported.")
 
@@ -42,9 +46,9 @@ def main() -> int:
     chosen = random.choice(all_lgtm)
 
     output = gif_to_string_output(
-        **chosen,
+        chosen,
         output_format=StringOutputFormat.HTML,
-        width=500,
+        desired_width=500,
     )
     print(output)
     return 0

--- a/lgtm_db/__init__.py
+++ b/lgtm_db/__init__.py
@@ -28,7 +28,7 @@ def gif_to_string_output(
 
     if output_format == StringOutputFormat.HTML:
         width = desired_width or 500  # TODO: add logic for gif["width"]
-        height = width / aspect_ratio
+        height = int(width / aspect_ratio)
         return f'<img alt="{name}" src="{url}" width="{width}" height="{height}">'
     if output_format == StringOutputFormat.MARKDOWN:
         if desired_width is not None:

--- a/lgtm_db/data/db.yaml
+++ b/lgtm_db/data/db.yaml
@@ -1,70 +1,138 @@
 images:
   - name: git-push-and-go-home
     url: https://i.imgur.com/PKiCvz2.png
+    width: 700
+    height: 700
   - name: doge-much-code-very-lgtm
     url: https://memegenerator.net/img/instances/64675441.jpg
+    width: 1280
+    height: 960
   - name: success-kid-shipit
     url: https://memegenerator.net/img/instances/68718219.jpg
+    width: 400
+    height: 400
 gifs:
   - name: seal-of-approval-seal
     url: https://media.giphy.com/media/13zeE9qQNC5IKk/giphy.gif
+    width: 250
+    height: 169
   - name: spongebob-many-thumbs-up
     url: https://media.giphy.com/media/3o7abGQa0aRJUurpII/giphy.gif
+    width: 540
+    height: 304
   - name: squidward-lacklustre-hooray
     url: https://media.giphy.com/media/l0HlTUsy3ZOuDSQtG/giphy.gif
+    width: 540
+    height: 304
   - name: spongebob-patrick-hooray
     url: https://media.giphy.com/media/3ohzAu2U1tOafteBa0/giphy.gif
+    width: 480
+    height: 360
   - name: simon-cowell-agt-thumbsup
     url: https://media.giphy.com/media/gqao9nM8RcSnYMgHnp/giphy.gif
+    width: 500
+    height: 500
   - name: terminator2-thumbsup
     url: https://media.giphy.com/media/gFwZfXIqD0eNW/giphy.gif
+    width: 500
+    height: 211
   - name: baby-girl-thumbsup-thankyou
     url: https://media.giphy.com/media/BYoRqTmcgzHcL9TCy1/giphy.gif
+    width: 358
+    height: 360
   - name: sand-dune-shipit
     url: https://media.giphy.com/media/xjZtu4qi1biIo/giphy.gif
+    width: 480
+    height: 360
   - name: asian-man-cubicle-thumbsup
     url: https://media.giphy.com/media/GCvktC0KFy9l6/giphy.gif
+    width: 300
+    height: 320
   - name: cat-wearing-shades-letsgo
     url: https://media.giphy.com/media/CjmvTCZf2U3p09Cn0h/giphy.gif
+    width: 480
+    height: 452
   - name: nicholas-cage-letsgo
     url: https://media.giphy.com/media/RrVzUOXldFe8M/giphy.gif
+    width: 349
+    height: 262
   - name: wwe-referee-thumbsup
     url: https://c.tenor.com/JS6Vtap-SYEAAAAC/wwe-wrestling.gif
+    width: 498
+    height: 389
   - name: domino-effect-self-high-five
     url: https://c.tenor.com/WBSIMZ5mHYAAAAAd/domino-effect-high-five.gif
+    width: 360
+    height: 352
   - name: trump-showing-lgtm
     url: http://i.imgur.com/JebWqWC.gif
+    width: 250
+    height: 218
   - name: borat-great-success
     url: https://media.giphy.com/media/a0h7sAqON67nO/giphy.gif
+    width: 480
+    height: 270
   - name: walkby-cat-high-five-shipit
     url: https://i.fluffy.cc/MKjDMmwXxZlqRTwnn070gVqZ8Rwh6d3p.gif
+    width: 340
+    height: 191
   - name: dog-in-front-of-laptop-lgtm
     url: https://media.giphy.com/media/eM0U5NQtVHu30VM5sS/giphy.gif
+    width: 298
+    height: 302
   - name: joey-friends-nice
     url: https://media.giphy.com/media/ftYpwfV6ZcerEa8poV/giphy.gif
+    width: 480
+    height: 392
   - name: dog-dressed-as-human-lgtm
     url: https://media.giphy.com/media/gLuP6eGC3yamBoGMJT/giphy.gif
+    width: 640
+    height: 360
   - name: gordon-ramsey-brilliant
     url: https://media.giphy.com/media/3oFzlX9khlRIev1E2Y/giphy.gif
+    width: 480
+    height: 270
   - name: pedro-pascal-fist-salute
     url: https://media.giphy.com/media/n58MqIchLqAalRQAQB/giphy.gif
+    width: 480
+    height: 270
   - name: choi-aera-fightformyway-thumbsup
     url: https://media.giphy.com/media/PL6d4VCbp1hhkF2wO9/giphy.gif
+    width: 607
+    height: 394
   - name: this-is-a-high-five-moment
     url: https://media.giphy.com/media/w5S93jM3bA3rbPTOpO/giphy.gif
+    width: 479
+    height: 270
   - name: unwilling-cat-low-five-shipit
     url: https://media.giphy.com/media/TLKp7l4rdWFMVfN5hP/giphy.gif
+    width: 373
+    height: 225
   - name: cat-standing-thankyou
     url: https://media.giphy.com/media/ucI5kRLqH0WXu/giphy.gif
+    width: 269
+    height: 478
   - name: multiple-pikachu-shipit
     url: https://i.fluffy.cc/BPgxZkmsrgmfcDFDCNWC3m4CW0gCJF7w.gif
+    width: 480
+    height: 270
   - name: sitting-cat-high-five
     url: https://i.fluffy.cc/TNRR0PklwSCMZlZHQkvpQPNl8h50SpgP.gif
+    width: 500
+    height: 281
   - name: husky-jumping-shipit
     url: https://i.fluffy.cc/b6wlBbdVkX83CHpLWxHZw74WJxHVQc9S.gif
+    width: 329
+    height: 349
   - name: carrying-dog-shipit-plz
     url: https://i.fluffy.cc/7WXqprWzDtCpbfprBZG1Hngnp7H7pfQm.gif
+    width: 320
+    height: 177
   - name: kitten-low-five-shipit
     url: https://i.fluffy.cc/3X84Bq2RR182XcPr0NTKKCp7wvNT8MhD.gif
+    width: 500
+    height: 270
   - name: believe-flying-puppy-shipit
     url: https://media.giphy.com/media/37YkA62o0EacPqD0xm/giphy.gif
+    width: 480
+    height: 453

--- a/scripts/generate_gallery.py
+++ b/scripts/generate_gallery.py
@@ -10,12 +10,12 @@ def render_section(resources: list, section_title: str) -> str:
     section_content = []
     section_content.append(f"## {section_title.title()}")
 
-    for r in resources:
-        name = r["name"]
+    for rsrc in resources:
+        name = rsrc["name"]
         img_tag = gif_to_string_output(
-            **r,
+            rsrc,
             output_format=StringOutputFormat.HTML,
-            width=420,
+            desired_width=420,
         )
         section_content.append(rf"**Name**: {name}<br>{img_tag}")
 

--- a/scripts/get_width_height.py
+++ b/scripts/get_width_height.py
@@ -1,0 +1,34 @@
+"""Temporary script to append on width and height attributes to db.yaml
+
+Needs cleaning up... And move to using async, etc.
+"""
+from io import BytesIO
+from pathlib import Path
+
+import requests
+import yaml
+from PIL import Image
+
+
+def get_size(url):
+    image_raw = requests.get(url)
+    image = Image.open(BytesIO(image_raw.content))
+    return image.size
+
+
+project_path = Path(__file__).parent.parent
+
+db_path = project_path / "lgtm_db" / "data" / "db.yaml"
+with db_path.open(mode="r") as f:
+    ps = yaml.safe_load(f)
+
+all_contents = ps["images"] + ps["gifs"]
+for p in all_contents:
+    sze = get_size(p["url"])
+    p["width"] = sze[0]
+    p["height"] = sze[1]
+    print(p["name"])
+
+new_db_path = db_path.parent / "new_db.yaml"
+with new_db_path.open(mode="w") as f:
+    yaml.safe_dump(ps, f, sort_keys=False)

--- a/scripts/get_width_height.py
+++ b/scripts/get_width_height.py
@@ -24,10 +24,9 @@ with db_path.open(mode="r") as f:
 
 all_contents = ps["images"] + ps["gifs"]
 for p in all_contents:
-    sze = get_size(p["url"])
-    p["width"] = sze[0]
-    p["height"] = sze[1]
     print(p["name"])
+    sze = get_size(p["url"])
+    p["width"], p["height"] = sze
 
 new_db_path = db_path.parent / "new_db.yaml"
 with new_db_path.open(mode="w") as f:


### PR DESCRIPTION
Partially motivated by the lazy loading PR (#10), where the width and height attributes are needed on every image.

But also, now we should be able to use the actual width/height information to calculate aspect ratio, and resize accordingly if `width` is specified.

Additional todo:
* script to verify width / height (probably create a separate issue) in `db.yaml`, using async
* incorporate width/height logic into the `gif_to_string_output` function definition.