### PR TITLE
fix: take 'Approve additionally' into account

### DIFF
--- a/scripts/greasemonkey/lgtm-gifs-gitlab.user.js
+++ b/scripts/greasemonkey/lgtm-gifs-gitlab.user.js
@@ -38,7 +38,7 @@
             e.target.innerText
         );
 
-        if (all_lgtm.length && e.target.className === "gl-button-text" && e.target.innerText === "Approve") {
+        if (all_lgtm.length && e.target.className === "gl-button-text" && e.target.innerText.startsWith("Approve")) {
             console.log("inside approved if-block");
 
             // user just clicked on the "Approve" button


### PR DESCRIPTION
The "Approve" button on Gitlab changes to "Approve additionally" instead when another person has already approved the MR.

This PR change will take this into account, so that when we click on "Approve additionally", the lgtm gif **still** gets loaded into the comment box.