### PR TITLE
chore: fix license_file is deprecated warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ long_description_content_type = text/markdown
 url = https://github.com/thatlittleboy/lgtm-db
 author = Jeremy Goh
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 
 [options]
 packages = find:


### PR DESCRIPTION
Ref: https://github.com/pypa/setuptools/pull/2620