### PR TITLE
chore: add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           diff docs/index.html docs/index-old.html
 
   run-pytest:
-    name: Runs pytest Tests
+    name: Runs pytest tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,10 @@ name: Tests
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-gallery-html:
     name: Checks if the gallery html file is up-to-date
@@ -24,3 +28,27 @@ jobs:
           mv docs/index.html docs/index-old.html
           python -m scripts.generate_gallery
           diff docs/index.html docs/index-old.html
+
+  run-pytest:
+    name: Runs pytest Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup python dependencies
+        run: pip install ".[dev]"
+
+      - name: Run pytest
+        run: |
+          pytest

--- a/lgtm_db/matcher.py
+++ b/lgtm_db/matcher.py
@@ -5,6 +5,9 @@ class Matcher:
     """A helper class for encapsulating matching logic for filtering."""
 
     def __init__(self, condition: str):
+        if not isinstance(condition, str):
+            raise TypeError(f"condition: expected a str, got {type(condition)}")
+
         self.condition = condition
         self.regexed: bool = self.is_regex_pattern(condition)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,11 @@ dev =
     Pillow
     asyncio
     aiohttp
+    pytest
+
+[options.packages.find]
+exclude =
+    tests*
 
 [bdist_wheel]
 universal = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+@pytest.fixture(scope="package")
+def sample_gifs():
+    gifs = [
+        {
+            "name": "doge-thumbsup",
+            "url": "https://xyz.com/doge",
+            "width": 350,
+            "height": 400,
+        },
+        {
+            "name": "cat-thumbsup",
+            "url": "https://xyz.com/cat",
+            "width": 380,
+            "height": 350,
+        },
+    ]
+    return gifs
+
+
+@pytest.fixture(scope="package")
+def sample_yaml_filepath():
+    filepath = Path("sample_db.yaml")
+
+    gifs = dedent(
+        """\
+        images: []
+        gifs:
+          - name: doge-thumbsup
+            url: https://xyz.com/doge
+            width: 350
+            height: 400
+          - name: cat-thumbsup
+            url: https://xyz.com/cat
+            width: 380
+            height: 350
+        """,
+    )
+    filepath.write_text(gifs)
+    yield filepath
+    filepath.unlink()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,12 @@ def sample_gifs():
             "height": 400,
         },
         {
+            "name": "doge-crying",
+            "url": "https://xyz.com/doge",
+            "width": 850,
+            "height": 300,
+        },
+        {
             "name": "cat-thumbsup",
             "url": "https://xyz.com/cat",
             "width": 380,
@@ -35,6 +41,10 @@ def sample_yaml_filepath():
             url: https://xyz.com/doge
             width: 350
             height: 400
+          - name: doge-crying
+            url: https://xyz.com/doge
+            width: 850
+            height: 300
           - name: cat-thumbsup
             url: https://xyz.com/cat
             width: 380

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -7,7 +7,7 @@ def test_load_from_yaml(sample_yaml_filepath):
     gloader = GifLoader.from_yaml(sample_yaml_filepath)
 
     # check gifs are loaded properly
-    assert len(gloader.gifs) == 2
+    assert len(gloader.gifs) == 3
     expected_keys = {"name", "url", "width", "height"}
     assert not gloader.gifs[0].keys() ^ expected_keys
 
@@ -16,7 +16,7 @@ def test_load_from_gifs(sample_gifs):
     gloader = GifLoader(sample_gifs)
 
     # check gifs are loaded properly
-    assert len(gloader.gifs) == 2
+    assert len(gloader.gifs) == 3
     expected_keys = {"name", "url", "width", "height"}
     assert not gloader.gifs[0].keys() ^ expected_keys
 
@@ -36,3 +36,72 @@ def test_error_when_picking_empty_after_masking(sample_gifs):
 
     with pytest.raises(EmptyGifLoaderError, match="No valid gifs"):
         gloader.pick_random()
+
+
+def test_single_filter_by_name_inclusive(sample_gifs):
+    candidates = GifLoader(sample_gifs).filter_by_name(name="doge-thum")._get_candidates()
+
+    assert len(candidates) == 1
+    assert candidates[0]["name"] == "doge-thumbsup"
+
+
+def test_single_filter_by_name_exclusive(sample_gifs):
+    candidates = GifLoader(sample_gifs).filter_by_name(name="doge", complement=True)._get_candidates()
+
+    assert len(candidates) == 1
+    assert candidates[0]["name"] == "cat-thumbsup"
+
+
+def test_multiple_filter_by_name_inc(sample_gifs):
+    # inclusive-only
+    candidates = (
+        GifLoader(sample_gifs).filter_by_name(name="doge-thum").filter_by_name(name="cat")._get_candidates()
+    )
+
+    assert len(candidates) == 2
+    expected_names = {
+        "doge-thumbsup",
+        "cat-thumbsup",
+    }
+    actual_names = {c["name"] for c in candidates}
+    assert not expected_names ^ actual_names
+
+
+def test_multiple_filter_by_name_exc(sample_gifs):
+    # exclusive-only
+    candidates = (
+        GifLoader(sample_gifs)
+        .filter_by_name(name="doge-thum", complement=True)
+        .filter_by_name(name="cat", complement=True)
+        ._get_candidates()
+    )
+
+    assert len(candidates) == 1
+    expected_names = {
+        "doge-crying",
+    }
+    actual_names = {c["name"] for c in candidates}
+    assert not expected_names ^ actual_names
+
+
+def test_multiple_filter_by_name_mixed1(sample_gifs):
+    """When applying multiple filters, order matters!
+
+    Exclusions are given higher priority than inclusions, which means we run the inclusion masking first,
+    before running the exclusion masking.
+
+    """
+    # inclusive, then exclusive
+    candidates = (
+        GifLoader(sample_gifs)
+        .filter_by_name(name="thumbsup", complement=False)
+        .filter_by_name(name="doge", complement=True)
+        ._get_candidates()
+    )
+
+    assert len(candidates) == 1
+    expected_names = {
+        "cat-thumbsup",
+    }
+    actual_names = {c["name"] for c in candidates}
+    assert not expected_names ^ actual_names

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,38 @@
+import pytest
+
+from lgtm_db.loader import EmptyGifLoaderError, GifLoader
+
+
+def test_load_from_yaml(sample_yaml_filepath):
+    gloader = GifLoader.from_yaml(sample_yaml_filepath)
+
+    # check gifs are loaded properly
+    assert len(gloader.gifs) == 2
+    expected_keys = {"name", "url", "width", "height"}
+    assert not gloader.gifs[0].keys() ^ expected_keys
+
+
+def test_load_from_gifs(sample_gifs):
+    gloader = GifLoader(sample_gifs)
+
+    # check gifs are loaded properly
+    assert len(gloader.gifs) == 2
+    expected_keys = {"name", "url", "width", "height"}
+    assert not gloader.gifs[0].keys() ^ expected_keys
+
+
+def test_error_when_picking_empty_initial():
+    """Should raise error if gifs is empty at time of picking."""
+    gloader = GifLoader([])
+
+    with pytest.raises(EmptyGifLoaderError, match="No valid gifs"):
+        gloader.pick_random()
+
+
+def test_error_when_picking_empty_after_masking(sample_gifs):
+    """Should raise error if gifs is empty at time of picking."""
+    gloader = GifLoader(sample_gifs)
+    gloader.filter_by_name(name="aghast")
+
+    with pytest.raises(EmptyGifLoaderError, match="No valid gifs"):
+        gloader.pick_random()

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,25 @@
+from lgtm_db.matcher import Matcher
+
+
+def test_matcher_type():
+    # regex
+    assert Matcher.is_regex_pattern("^$")
+    assert Matcher.is_regex_pattern(r"^good.+$")
+
+    # string
+    assert not Matcher.is_regex_pattern("")
+    assert not Matcher.is_regex_pattern(r"lgtm_gif")
+    assert not Matcher.is_regex_pattern(r"$hahah$")
+
+
+def test_match_for_regex():
+    assert Matcher(r"^good.+$").match("good-boy")
+    assert Matcher(r"^good.boy$").match("good-boy")
+    assert not Matcher(r"^good$").match("good-boy")
+
+
+def test_match_for_string():
+    """When matching on string, should be a "substring" logic."""
+    assert Matcher("good").match("good-boy")
+    assert not Matcher("bad").match("good-boy")
+    assert not Matcher("good.boy").match("good-boy")

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lgtm_db.matcher import Matcher
 
 
@@ -10,6 +12,12 @@ def test_matcher_type():
     assert not Matcher.is_regex_pattern("")
     assert not Matcher.is_regex_pattern(r"lgtm_gif")
     assert not Matcher.is_regex_pattern(r"$hahah$")
+
+
+def test_condition_is_wrong_type():
+    with pytest.raises(TypeError, match="expected a str, got"):
+        _ = Matcher(None)
+        _ = Matcher(123)
 
 
 def test_match_for_regex():


### PR DESCRIPTION
* chore: Initialize the pytest framework in this project, add tests for existing module functionality. Leave the tests for the CLI argparsing to another PR.
* ci: Add github CI workflow to run tests.
* fix: Add a simple test for checking wrong input type for `Matcher`'s condition. Now a TypeError will be raised if a non-string is passed in.

Resolves #38 .