### PR TITLE
feat: remove dead links from memegenerator

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,15 +34,9 @@
     <b>
       Name
     </b>
-    : doge-much-code-very-lgtm
+    : smiling-cat-face-lgtm
     <br>
-    <img loading="lazy" alt="doge-much-code-very-lgtm" src="https://memegenerator.net/img/instances/64675441.jpg" width="420" height="315">
-    <b>
-      Name
-    </b>
-    : success-kid-shipit
-    <br>
-    <img loading="lazy" alt="success-kid-shipit" src="https://memegenerator.net/img/instances/68718219.jpg" width="420" height="420">
+    <img loading="lazy" alt="smiling-cat-face-lgtm" src="https://i.imgur.com/DUiOvL7.png" width="420" height="384">
     <h2>
       Gifs
     </h2>

--- a/lgtm_db/data/db.yaml
+++ b/lgtm_db/data/db.yaml
@@ -3,14 +3,10 @@ images:
     url: https://i.imgur.com/PKiCvz2.png
     width: 700
     height: 700
-  - name: doge-much-code-very-lgtm
-    url: https://memegenerator.net/img/instances/64675441.jpg
-    width: 1280
-    height: 960
-  - name: success-kid-shipit
-    url: https://memegenerator.net/img/instances/68718219.jpg
+  - name: smiling-cat-face-lgtm
+    url: https://i.imgur.com/DUiOvL7.png
     width: 400
-    height: 400
+    height: 366
 gifs:
   - name: seal-of-approval-seal
     url: https://media.giphy.com/media/13zeE9qQNC5IKk/giphy.gif


### PR DESCRIPTION
BREAKING CHANGE.

Since we are removing 2 images. (`doge-much-code-very-lgtm` and `success-kid-shipit`). These images are no longer available on memegenerator.com. Not going to replicate the images since I don't quite like memes anyway.

And replacing with one new lgtm cat image.

<img alt="smiling-cat-face-lgtm" src="https://i.imgur.com/DUiOvL7.png" >
