### PR TITLE
feat: allow specification of width via CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can then pipe the result into `pbcopy` etc. to copy the result into your cli
 **WARNING**: API is very much subject to change.
 
 ```
-usage: lgtm-db [-h] [-V] [-I PATTERN] [-E PATTERN]
+usage: lgtm-db [-h] [-V] [-I PATTERN] [-E PATTERN] [-wd WIDTH]
 
 Get a randomly-generated LGTM gif or image.
 
@@ -57,6 +57,9 @@ optional arguments:
                         with ^ and ends with $. For non-regex conditions, a simple substring check is
                         used. Multiple conditions are supported. Exclusions are given higher priority
                         over inclusions.
+  -wd WIDTH, --width WIDTH
+                        Specify the width of the output gif. A non-positive width will result in an
+                        error. Only applicable for HTML.
 ```
 
 ### Browser user script


### PR DESCRIPTION
**Note:** I originally considered supporting `-ht / --height` as well, but decided against it for now. I don't really want to allow non-conforming aspect-ratio images.

But in theory it is possible. (If height is specified, then calculate aspect ratio and the width based on input height).

---

**BREAKING CHANGE**. Kinda(?) The default width generated by the `lgtm-db` CLI used to be 500px, now it will be the original size of the gif if user does not specify `-wd/--width` directly.

Currently also missing tests...