### PR TITLE
feat: add nsp thumbs up man gif

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -274,5 +274,11 @@
     : husky-head-through-door-flap-thankyou
     <br>
     <img loading="lazy" alt="husky-head-through-door-flap-thankyou" src="https://c.tenor.com/FK16Bus5_S0AAAAd/husky-huskies.gif" width="420" height="420">
+    <b>
+      Name
+    </b>
+    : singapore-nsp-thumbsup-man
+    <br>
+    <img loading="lazy" alt="singapore-nsp-thumbsup-man" src="https://media.giphy.com/media/e5z13ZQwKmj9X6ILcQ/giphy.gif" width="420" height="299">
   </body>
 </html>

--- a/lgtm_db/data/db.yaml
+++ b/lgtm_db/data/db.yaml
@@ -164,3 +164,7 @@ gifs:
     url: https://c.tenor.com/FK16Bus5_S0AAAAd/husky-huskies.gif
     width: 498
     height: 498
+  - name: singapore-nsp-thumbsup-man
+    url: https://media.giphy.com/media/e5z13ZQwKmj9X6ILcQ/giphy.gif
+    width: 473
+    height: 337


### PR DESCRIPTION
<img alt="singapore-nsp-thumbsup-man" src="https://media.giphy.com/media/e5z13ZQwKmj9X6ILcQ/giphy.gif" width="473" height="337">

Original source (video clip): https://www.youtube.com/watch?v=uad3MzWsDCY
Original source (tenor gif): https://tenor.com/view/thumbs-up-nsp-thumbs-up-man-approve-gif-17594936