### PR TITLE
chore: drop support for python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
 
     steps:
       - name: Checkout repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/asottile/add-trailing-comma
     rev: v2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         args: [--py36-plus]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
 
@@ -50,7 +50,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.206
+    rev: v0.0.220
     hooks:
       - id: ruff
         types: [python]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ View all the available images and gifs in the [gallery page](https://thatlittleb
 
 This project is just for personal use, so it is not published on PyPI.
 
-Using [pipx](https://pypa.github.io/pipx/) (Python 3.7+ only) to install directly from github:
+Using [pipx](https://pypa.github.io/pipx/) (Python 3.8+ only) to install directly from github:
 
 ```shell
 $ pipx install git+https://github.com/thatlittleboy/lgtm-db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ select = [
 ]
 ignore = ["E501", "F403"]
 force-exclude = true
-target-version = "py37"
+target-version = "py38"
 
 [build-system]
 requires = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ license_files = LICENSE
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     pyyaml
     importlib_resources;python_version<"3.9"


### PR DESCRIPTION
because py3.7 EOL is Jun 2023. And I feel like upgrading.

Also start testing on py3.12