### PR TITLE
chore: fix pr-checker length minimum requirement

### DIFF
--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -36,5 +36,5 @@ jobs:
             release
           requireScope: false
           # subject must not begin with an uppercase letter, and must be at least
-          # be 10 characters long
-          subjectPattern: ^(?![A-Z]).{10,}$
+          # be 6 characters long
+          subjectPattern: ^(?![A-Z]).{6,}$


### PR DESCRIPTION
I forgot that my release subject messages are of the form "vx.y.z" which are only 6 characters long.