### PR TITLE
chore: add COM to ruff checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         args: ["--config", "pyproject.toml"]
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.2
+    rev: v2.1.3
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]
@@ -50,7 +50,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.220
+    rev: v0.0.223
     hooks:
       - id: ruff
         types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ select = [
     "D410", "D411", "D413",
     # flake8-bugbear
     "B",
+    # flake8-commas
+    "COM",
     # flake8-comprehensions
     "C4",
     # flake8-errmsg


### PR DESCRIPTION
ruff v0.0.223 onwards, `ruff` implemented flake8-commas :)