### PR TITLE
refactor: shorten giphy url

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -291,7 +291,7 @@
     </b>
     : baby-biscuit-expression-change
     <br>
-    <img loading="lazy" alt="baby-biscuit-expression-change" src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExODMzYWExMjZjYTM3YWNmZGIxYjJkMmFiNDhhMGRjNjI5ZDU5YjFmNiZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/Acx1QcsVJ7XrgD99JR/giphy.gif" width="420" height="315">
+    <img loading="lazy" alt="baby-biscuit-expression-change" src="https://media.giphy.com/media/Acx1QcsVJ7XrgD99JR/giphy.gif" width="420" height="315">
     <b>
       Name
     </b>
@@ -303,6 +303,6 @@
     </b>
     : head-swing-iloveit-thumbsup
     <br>
-    <img loading="lazy" alt="head-swing-iloveit-thumbsup" src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYTRlMzdiOTA4NTI2N2VhZmU0NGEyZTE0MGRjZGZhMjU4NWViNGQ2MiZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/2GaZZLgA9lxra/giphy.gif" width="420" height="196">
+    <img loading="lazy" alt="head-swing-iloveit-thumbsup" src="https://media.giphy.com/media/2GaZZLgA9lxra/giphy.gif" width="420" height="196">
   </body>
 </html>

--- a/lgtm_db/data/db.yaml
+++ b/lgtm_db/data/db.yaml
@@ -173,7 +173,7 @@ gifs:
     width: 392
     height: 220
   - name: baby-biscuit-expression-change
-    url: https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExODMzYWExMjZjYTM3YWNmZGIxYjJkMmFiNDhhMGRjNjI5ZDU5YjFmNiZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/Acx1QcsVJ7XrgD99JR/giphy.gif
+    url: https://media.giphy.com/media/Acx1QcsVJ7XrgD99JR/giphy.gif
     width: 600
     height: 450
   - name: law-and-order-mirror-thumbsup
@@ -181,6 +181,6 @@ gifs:
     width: 500
     height: 281
   - name: head-swing-iloveit-thumbsup
-    url: https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYTRlMzdiOTA4NTI2N2VhZmU0NGEyZTE0MGRjZGZhMjU4NWViNGQ2MiZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/2GaZZLgA9lxra/giphy.gif
+    url: https://media.giphy.com/media/2GaZZLgA9lxra/giphy.gif
     width: 480
     height: 224


### PR DESCRIPTION
The long `v1.xxxxx` string seems to be non-essential to the final link, so remove it. Just in case it is some tracker/cookie thing. -.-