### PR TITLE
chore: use uv and upgrade actions

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - id: db_count
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,16 +28,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           check-latest: false
 
       - name: Setup python dependencies
-        run: pip install ".[dev]"
+        # Do regular install NOT editable install
+        run: |
+          python -m pip install --upgrade uv
+          uv pip install --system '.[dev]'
 
       - name: Run the comparison of gallery files
         run: |
@@ -55,21 +58,24 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         # include:
-        #   - python-version: "3.12-dev"
+        #   - python-version: "3.13-dev"
         #     experimental: true
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: false
 
       - name: Setup python dependencies
-        run: pip install ".[dev]"
+        # Do regular install NOT editable install
+        run: |
+          python -m pip install --upgrade uv
+          uv pip install --system '.[dev]'
 
       - name: Run pytest
         run: |


### PR DESCRIPTION
1. Use uv instead of pip install (just a teeny bit faster?) Tests run in 6s on average rather than 11s.
2. Upgrade various github actions versions.